### PR TITLE
CSS Anpassung und Notice vermeiden

### DIFF
--- a/classes/class.rex_focuspoint.inc.php
+++ b/classes/class.rex_focuspoint.inc.php
@@ -93,7 +93,7 @@ echo'
 
 	echo '
 	<style>
-		.helper-tool-target img.target-overlay, .helper-tool-target img.reticle  {
+		.helper-tool-target img.reticle  {
         	top: '.$css_y.';
 			left: '.$css_x.';
 		}


### PR DESCRIPTION
CSS Anpassung, damit der Focuspoint dort ist wo man hin geklickt hat.
